### PR TITLE
fix: add GH_TOKEN environment variable to build job in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Build
     needs: lint-and-type-check
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This pull request makes a small update to the CI/CD workflow by adding an environment variable to the build job. The change ensures that the `GH_TOKEN` is available during the build process for any steps that require authentication with GitHub.

* Added the `GH_TOKEN` environment variable to the `Build` job in `.github/workflows/ci-cd.yml` to provide GitHub authentication for build steps.